### PR TITLE
Jupyter-book build and gh-pages deployment workflow

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,0 +1,41 @@
+name: deploy-book
+
+# Only run this when the master branch changes
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+# This job installs dependencies, build the book, and pushes it to `gh-pages`
+jobs:
+  deploy-book:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    # Install dependencies
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.11
+
+    - name: Install dependencies
+      run: |
+        pip install -r docs/requirements.txt
+
+
+    # Build the book
+    - name: Build the book
+      run: |
+        PYTHONPATH=./ jupyter-book build docs
+
+    # Push the book's HTML to github-pages
+    - name: GitHub Pages action
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs/_build/html

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,2 @@
+_build
+.DS_Stores

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -43,4 +43,6 @@ sphinx:
   - 'sphinx.ext.autosummary'
   config:
     autosummary_generate: True
+    napoleon_google_docstring: True
+    napoleon_numpy_docstring: True
     bibtex_reference_style: author_year

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,46 @@
+# Book settings
+# Learn more at https://jupyterbook.org/customize/config.html
+
+title: GRID-Dendro
+author: Sanghyuk Moon
+copyright: "2023"
+# logo: logo.png
+
+# Force re-execution of notebooks on each build.
+# See https://jupyterbook.org/content/execute.html
+execute:
+  execute_notebooks: force
+
+# Define the name of the latex output file for PDF builds
+latex:
+  latex_documents:
+    targetname: book.tex
+
+# Add a bibtex file so that we can create citations
+bibtex_bibfiles:
+  - references.bib
+
+# Information about where the book exists on the web
+repository:
+  url: https://github.com/sanghyukmoon/grid_dendro  # Online location of your book
+  path_to_book: book  # Optional path to your book, relative to the repository root
+  branch: master  # Which branch of the repository should be used when creating links (optional)
+
+# Add GitHub buttons to your book
+# See https://jupyterbook.org/customize/config.html#add-a-link-to-your-repository
+html:
+  use_issues_button: true
+  use_repository_button: true
+
+# launch_buttons:
+#   colab_url: "https://colab.research.google.com"
+
+sphinx:
+  extra_extensions:
+  - 'sphinx.ext.autodoc'
+  - 'sphinx.ext.napoleon'
+  - 'sphinx.ext.viewcode'
+  - 'sphinx.ext.autosummary'
+  config:
+    autosummary_generate: True
+    bibtex_reference_style: author_year

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -1,0 +1,15 @@
+# Table of contents
+# Learn more at https://jupyterbook.org/customize/toc.html
+
+format: jb-book
+root: intro
+parts:
+  - caption: API References
+    chapters:
+    - file: dendrogram
+    - file: boundary
+    - file: energy
+  - caption: Installation
+    chapters:
+    - file: installation
+    - file: bookbuild

--- a/docs/bookbuild.md
+++ b/docs/bookbuild.md
@@ -1,0 +1,23 @@
+# Building Documentation
+
+We use `jupyter-book`.
+
+An example can be found at https://github.com/changgoo/PRFM
+
+To build the document without a source code package sitting in the same folder, this trick helps.
+
+```sh
+PYTHONPATH=./ jupyter-book build docs/
+```
+
+To publish the document on `gh-pages` for the first time,
+please follow the [instruction](https://jupyterbook.org/en/stable/start/publish.html#publish-your-book-online-with-github-pages)
+
+In short, do the followings.
+
+```sh
+pip install ghp-import
+ghp-import -n -p -f docs/_build/html
+```
+
+We then use GitHub Workflow and GitHub Action for continuous deployment.

--- a/docs/boundary.rst
+++ b/docs/boundary.rst
@@ -1,0 +1,5 @@
+boundary
+--------
+
+.. automodule:: grid_dendro.boundary
+    :members:

--- a/docs/dendrogram.rst
+++ b/docs/dendrogram.rst
@@ -1,0 +1,5 @@
+Dendrogram class
+----------------
+
+.. autoclass:: grid_dendro.dendrogram.Dendrogram
+    :members:

--- a/docs/energy.rst
+++ b/docs/energy.rst
@@ -1,0 +1,4 @@
+Utility functions
+-----------------
+
+.. autofunction:: grid_dendro.energy.calculate_cumulative_energies

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,13 @@
+# Installation
+
+## Build from the source code
+
+```sh
+git clone git@github.com:sanghyukmoon/grid_dendro.git
+cd grid_dendro
+conda env create -f env.yml
+conda activate grid_dendro
+```
+
+(TODO) add `env.yml`
+

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,0 +1,19 @@
+# GRID-Dendro -- Gravitational Identification with Dendrogram
+
+[![Jupyter Book Badge](https://jupyterbook.org/badge.svg)](https://changgoo.github.io/grid_dendro)
+
+**WARNING: This package is under construction 🏗**
+
+## References and Historical Remarks
+- {cite:t}`GongOstriker2011`: GRID
+- {cite:t}`Mao2020`: FISO
+
+{cite:t}`GongOstriker2011` developed and introduced a core finding method called GRID (GRavitatianal IDentification), which utilize isocontours of gravitational potential to provide physically motivated definition of bound cores. {cite:t}`Mao2020` extended this algorithm to identify hierarchical structures of the interstellar medium using dendrogram, as well as significantly improve the efficiency of the algorithm. The first author of {cite:t}`Mao2020` wrote a python pacakge [FISO](https://github.com/alwinm/fiso) (fast isocontours) to implement this algorithm.
+
+`grid_dendro` is an implementation of an algorithm presented in {cite:t}`Mao2020`, written by refactoring the original [FISO](https://github.com/alwinm/fiso) code base to enhance readability and maintainability.
+
+## Usage
+
+## References
+```{bibliography}
+```

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,0 +1,39 @@
+@ARTICLE{Mao2020,
+       author = {{Mao}, S. Alwin and {Ostriker}, Eve C. and {Kim}, Chang-Goo},
+        title = "{Cloud Properties and Correlations with Star Formation in Self-consistent Simulations of the Multiphase ISM}",
+      journal = {\apj},
+     keywords = {Star formation, Star-forming regions, Giant molecular clouds, Interstellar medium, 1569, 1565, 653, 847, Astrophysics - Astrophysics of Galaxies},
+         year = 2020,
+        month = jul,
+       volume = {898},
+       number = {1},
+          eid = {52},
+        pages = {52},
+          doi = {10.3847/1538-4357/ab989c},
+archivePrefix = {arXiv},
+       eprint = {1911.05078},
+ primaryClass = {astro-ph.GA},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2020ApJ...898...52M},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{GongOstriker2011,
+       author = {{Gong}, Hao and {Ostriker}, Eve C.},
+        title = "{Dense Core Formation in Supersonic Turbulent Converging Flows}",
+      journal = {\apj},
+     keywords = {ISM: structure, methods: numerical, stars: formation, turbulence, Astrophysics - Solar and Stellar Astrophysics},
+         year = 2011,
+        month = mar,
+       volume = {729},
+       number = {2},
+          eid = {120},
+        pages = {120},
+          doi = {10.1088/0004-637X/729/2/120},
+archivePrefix = {arXiv},
+       eprint = {1101.2650},
+ primaryClass = {astro-ph.SR},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2011ApJ...729..120G},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+jupyter-book
+docutils==0.17.1

--- a/grid_dendro/energy.py
+++ b/grid_dendro/energy.py
@@ -4,16 +4,24 @@ from grid_dendro import dendrogram
 def calculate_cumulative_energies(prims, dvol, nodes, node):
     """Calculate cumulative energies as a function of radius in a given node
 
-    Args:
-        prims: dictionary containing primitive variables.
-        dvol: float representing volume element.
-        nodes: grid_dendro nodes dictionary.
-        node: int representing the selected node.
+    Parameters
+    ----------
+        prims : dict
+            dictionary containing primitive variables.
+        dvol : float
+            representing volume element.
+        nodes : dict
+            grid_dendro nodes dictionary.
+        node : int
+            representing the selected node.
 
-    Returns:
-        reff: effective radii.
-        energies: thermal, kinetic, gravitational, and total energies
-          integrated up to each radius.
+    Returns
+    -------
+        reff : float
+            effective radii.
+        energies : dict
+            thermal, kinetic, gravitational, and total energies
+            integrated up to each radius.
     """
 
     # Create 1-D flattened primitive variables of this node


### PR DESCRIPTION
* A documentation builder using jupyter-book is added in docs/ folder
* GitHub workflow is added in .github/workflows/

The deployed page will look like this.
https://changgoo.github.io/grid_dendro/intro.html